### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/ndarrayext.rs
+++ b/src/ndarrayext.rs
@@ -20,9 +20,9 @@ where
     }
 }
 
-pub fn diff<'a, T: 'a, D, V>(data: V, axis: Option<Axis>) -> Array<T, D>
+pub fn diff<'a, T, D, V>(data: V, axis: Option<Axis>) -> Array<T, D>
 where
-    T: Real<T>,
+    T: Real<T> + 'a,
     D: Dimension,
     V: AsArray<'a, T, D>,
 {
@@ -134,9 +134,9 @@ where
 /// Returns the indices of the bins to which each value in input array belongs
 ///
 /// This code works if `bins` is increasing
-pub fn digitize<'a, T: 'a, A, B>(arr: A, bins: B) -> Array1<usize>
+pub fn digitize<'a, T, A, B>(arr: A, bins: B) -> Array1<usize>
 where
-    T: Real<T>,
+    T: Real<T> + 'a,
     // T: Clone  + NdFloat + AlmostEqual,
     A: AsArray<'a, T, Ix1>,
     B: AsArray<'a, T, Ix1>,
@@ -152,9 +152,13 @@ where
         .enumerate()
         .sorted_by(|e1, e2| e1.1.partial_cmp(e2.1).unwrap())
     {
-        let mut k = kstart;
-
-        for bins_win in bins_view.slice(s![kstart..]).windows(2) {
+        for (offset, bins_win) in bins_view
+            .slice(s![kstart..])
+            .windows(2)
+            .into_iter()
+            .enumerate()
+        {
+            let k = kstart + offset;
             let bl = bins_win[0];
             let br = bins_win[1];
 
@@ -163,8 +167,6 @@ where
                 kstart = k;
                 break;
             }
-
-            k += 1;
         }
     }
 

--- a/src/ndg.rs
+++ b/src/ndg.rs
@@ -268,8 +268,8 @@ where
     /// - If the spline yet has not been computed
     ///
     pub fn evaluate(&self, xi: &[ArrayView1<'a, T>]) -> Result<Array<T, D>> {
-        self.evaluate_validate(&xi)?;
-        let yi = self.evaluate_spline(&xi);
+        self.evaluate_validate(xi)?;
+        let yi = self.evaluate_spline(xi);
 
         Ok(yi)
     }

--- a/src/ndg/evaluate.rs
+++ b/src/ndg/evaluate.rs
@@ -62,6 +62,6 @@ where
     D: Dimension,
 {
     pub(super) fn evaluate_spline(&self, xi: &[ArrayView1<'a, T>]) -> Array<T, D> {
-        self.spline.as_ref().unwrap().evaluate_spline(&xi)
+        self.spline.as_ref().unwrap().evaluate_spline(xi)
     }
 }

--- a/src/sprsext.rs
+++ b/src/sprsext.rs
@@ -23,7 +23,7 @@ where
         let mut j: usize = 0;
 
         if offset < 0 {
-            i = offset.abs() as usize;
+            i = offset.unsigned_abs();
         } else {
             j = offset as usize;
         }
@@ -54,12 +54,10 @@ where
             } else {
                 row_head()
             }
+        } else if rows >= cols {
+            row_head()
         } else {
-            if rows >= cols {
-                row_head()
-            } else {
-                row_tail()
-            }
+            row_tail()
         };
 
         for l in 0..n {
@@ -105,7 +103,7 @@ where
     let first_row = if k >= 0 { 0 } else { (-k) as usize };
     let first_col = if k >= 0 { k as usize } else { 0 };
 
-    let diag_size = (rows - first_row).min(cols - first_col) as usize;
+    let diag_size = (rows - first_row).min(cols - first_col);
     let mut diag = Array1::<T>::zeros((diag_size,));
 
     for i in 0..diag_size {

--- a/src/umv/evaluate.rs
+++ b/src/umv/evaluate.rs
@@ -23,7 +23,7 @@ where
         xi: ArrayView1<'a, T>,
     ) -> Array2<T> {
         let edges = {
-            let mesh = breaks.slice(s![1 as i32..-1]);
+            let mesh = breaks.slice(s![1..breaks.len() - 1]);
             let one = Array1::<T>::ones((1,));
             let left_bound = &one * T::neg_infinity();
             let right_bound = &one * T::infinity();
@@ -31,7 +31,7 @@ where
             concatenate![Axis(0), left_bound, mesh, right_bound]
         };
 
-        let mut indices = digitize(&xi, &edges);
+        let mut indices = digitize(xi, &edges);
 
         // Go to local coordinates
         let xi = {

--- a/src/umv/make.rs
+++ b/src/umv/make.rs
@@ -138,13 +138,13 @@ where
             };
 
             let c3 = vpad(&(usol * smooth));
-            let c3_head = c3.slice(s![..-1 as i32, ..]);
-            let c3_tail = c3.slice(s![1 as i32.., ..]);
+            let c3_head = c3.slice(s![..c3.nrows() - 1, ..]);
+            let c3_tail = c3.slice(s![1.., ..]);
 
             let p1 = diff(&c3, Some(Axis(0))) / &dx;
             let p2 = &c3_head * three;
             let p3 = diff(&yi, Some(Axis(0))) / &dx - (&c3_head * two + c3_tail) * dx;
-            let p4 = yi.slice(s![..-1 as i32, ..]); // was yi.view()
+            let p4 = yi.slice(s![..yi.nrows() - 1, ..]); // was yi.view()
 
             drop(c3);
 


### PR DESCRIPTION
Clean up needless borrows, redundant casts, ambiguous slice ranges, and loop counter usage so release verification passes clippy.