### PR TITLE
Refine crate package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ readme = "README.md"
 license = "MIT"
 
 edition = "2021"
+rust-version = "1.85.0"
+exclude = [
+    ".github/",
+    ".gitignore",
+    "assets/",
+]
 
 
 [badges]


### PR DESCRIPTION
Set the minimum supported Rust version and exclude CI/assets files from the published crate package.